### PR TITLE
Send a proper bitrate

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.hgtvcanada/URL/HGTV Canada/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.hgtvcanada/URL/HGTV Canada/ServiceCode.pys
@@ -79,7 +79,7 @@ def MediaObjectsForURL(url):
             MediaObject(
                 video_resolution = int(item['plfile$height']),
                 audio_channels = int(item['plfile$audioChannels']),
-                bitrate = int(item['plfile$bitrate']),
+                bitrate = int(item['plfile$bitrate'] / 1000),
                 duration = int(item['plfile$duration'] * 1000),
                 video_frame_rate = int(item['plfile$frameRate']),
                 parts = [


### PR DESCRIPTION
Fix for GHI reported here:

https://github.com/plexinc/plex-media-player/issues/1#issuecomment-149646585

This may need to be done for other channels as well, PMS is wanting bitrate in Kbps from what I can tell and we are passing 1000 times that with this code.